### PR TITLE
[Tests] Floss ELF support

### DIFF
--- a/src/decode-base64/test.yml
+++ b/src/decode-base64/test.yml
@@ -28,6 +28,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-base64.c base64.c -o test-decode-base64.exe
 
-Xfail:
-    - Linux-32bit
-

--- a/src/decode-from-global/test.yml
+++ b/src/decode-from-global/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-from-global.c -o test-decode-from-global.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-from-heap/test.yml
+++ b/src/decode-from-heap/test.yml
@@ -26,5 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
       i686-w64-mingw32-clang test-decode-from-heap.c -o bin/test-decode-from-heap.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-from-stack/test.yml
+++ b/src/decode-from-stack/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-from-stack.c -o bin/test-decode-from-stack.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-global-stackstrings/test.yml
+++ b/src/decode-global-stackstrings/test.yml
@@ -29,5 +29,4 @@ Build instructions (Cross compile for Windows on Linux): |
 
 Xfail:
     - all
-    - Linux-32bit
 

--- a/src/decode-in-place/test.yml
+++ b/src/decode-in-place/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-in-place.c -o bin/test-decode-in-place.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-local-stackstrings/test.yml
+++ b/src/decode-local-stackstrings/test.yml
@@ -27,5 +27,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-local-stackstrings.c -o bin/test-decode-decode-stackstrings.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-rc4/test.yml
+++ b/src/decode-rc4/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-rc4.c -o bin/test-decode-rc4.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-reencode-string/test.yml
+++ b/src/decode-reencode-string/test.yml
@@ -29,5 +29,3 @@ Build instructions (Cross compile for Windows on Linux): |
     rm test-decode-reencode-string.exe
     i686-w64-mingw32-clang test-decode-reencode-string.c -o bin/test-decode-reencode-string.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-single-byte-xor/test.yml
+++ b/src/decode-single-byte-xor/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-single-byte-xor.c -o bin/test-decode-single-byte-xor.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-split-stackstrings/test.yml
+++ b/src/decode-split-stackstrings/test.yml
@@ -27,6 +27,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-split-stackstrings.c -o bin/test-decode-split-stackstrings.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-stackstrings-move-to-global/test.yml
+++ b/src/decode-stackstrings-move-to-global/test.yml
@@ -26,5 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-stackstrings-move-to-global.c -o bin/test-decode-stackstrings-move-to-global.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-string-by-index/test.yml
+++ b/src/decode-string-by-index/test.yml
@@ -30,6 +30,3 @@ Build instructions (Cross compile for Windows on Linux): |
     eg. rm test-decode-string-by-index.exe
     eg. i686-w64-mingw32-clang test-decode-string-by-index.c -o bin/test-decode-string-by-index.exe
 
-Xfail:
-    - Linux-32bit
-

--- a/src/decode-string-with-header/test.yml
+++ b/src/decode-string-with-header/test.yml
@@ -26,5 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-string-with-header.c -o bin/test-decode-string-with-header.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-substitution-cipher/test.yml
+++ b/src/decode-substitution-cipher/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-substitution-cipher.c -o bin/test-decode-substitution-cipher.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-tightstring/test.yml
+++ b/src/decode-tightstring/test.yml
@@ -27,6 +27,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-tightstring.c -o bin/test-decode-tightstring.exe
 
-Xfail:
-    - Linux-32bit
-

--- a/src/decode-to-global/test.yml
+++ b/src/decode-to-global/test.yml
@@ -26,6 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-global.c -o bin/test-decode-to-global.exe
 
-Xfail:
-    - Linux-32bit
-

--- a/src/decode-to-heap/test.yml
+++ b/src/decode-to-heap/test.yml
@@ -26,6 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-heap.c -o bin/test-decode-to-heap.exe
 
-Xfail:
-    - Linux-32bit
-

--- a/src/decode-to-output-buf/test.yml
+++ b/src/decode-to-output-buf/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-output-buf.c -o bin/test-decode-to-output-buf.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-to-stack-rep-mov/test.yml
+++ b/src/decode-to-stack-rep-mov/test.yml
@@ -26,5 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-stack-rep-mov.c -o bin/test-decode-to-stack-rep-mov.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-to-stack/test.yml
+++ b/src/decode-to-stack/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-stack.c -o bin/test-decode-to-stack.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-wrapped-decoder/test.yml
+++ b/src/decode-wrapped-decoder/test.yml
@@ -31,5 +31,4 @@ Build instructions (Cross compile for Windows on Linux): |
 
 Xfail:
     - all
-    - Linux-32bit
 


### PR DESCRIPTION
Including Linux for testing ELF.


$ pytest -v tests/data/src/                                                                                                             ============================================================================ test session starts ============================================================================platform linux -- Python 3.9.2, pytest-7.4.4, pluggy-1.3.0 -- /usr/bin/python3                                                                                               cachedir: .pytest_cache                                                                                                                                                      rootdir: /mnt/e/Github/flare-floss                                                                                                                                           collected 64 items                                                                                                                                                                                                                                                                                                                                        tests/data/src/decode-base64/test.yml::test-decode-base64::Linux::32bit PASSED                                                                                        [  1%] tests/data/src/decode-base64/test.yml::test-decode-base64::Windows::32bit PASSED                                                                                      [  3%] tests/data/src/decode-base64/test.yml::test-decode-base64::Windows::64bit PASSED                                                                                      [  4%] tests/data/src/decode-from-global/test.yml::test-decode-from-global::Linux::32bit PASSED                                                                              [  6%] tests/data/src/decode-from-global/test.yml::test-decode-from-global::Windows::32bit PASSED                                                                            [  7%] tests/data/src/decode-from-global/test.yml::test-decode-from-global::Windows::64bit PASSED                                                                            [  9%] tests/data/src/decode-from-heap/test.yml::test-decode-from-heap::Linux::32bit PASSED                                                                                  [ 10%] tests/data/src/decode-from-heap/test.yml::test-decode-from-heap::Windows::32bit PASSED                                                                                [ 12%] tests/data/src/decode-from-heap/test.yml::test-decode-from-heap::Windows::64bit PASSED                                                                                [ 14%] tests/data/src/decode-from-stack/test.yml::test-decode-from-stack::Linux::32bit PASSED                                                                                [ 15%] tests/data/src/decode-from-stack/test.yml::test-decode-from-stack::Windows::32bit PASSED                                                                              [ 17%] tests/data/src/decode-from-stack/test.yml::test-decode-from-stack::Windows::64bit PASSED                                                                              [ 18%] tests/data/src/decode-global-stackstrings/test.yml::test-decode-global-stackstrings::Linux::32bit XFAIL (unsupported test case (known issue))                         [ 20%] tests/data/src/decode-global-stackstrings/test.yml::test-decode-global-stackstrings::Windows::32bit XFAIL (unsupported test case (known issue))                       [ 21%] tests/data/src/decode-global-stackstrings/test.yml::test-decode-global-stackstrings::Windows::64bit XFAIL (unsupported test case (known issue))                       [ 23%] tests/data/src/decode-in-place/test.yml::test-decode-in-place::Linux::32bit PASSED                                                                                    [ 25%] tests/data/src/decode-in-place/test.yml::test-decode-in-place::Windows::32bit PASSED                                                                                  [ 26%] tests/data/src/decode-in-place/test.yml::test-decode-in-place::Windows::64bit PASSED                                                                                  [ 28%] tests/data/src/decode-local-stackstrings/test.yml::test-decode-local-stackstrings::Linux::32bit PASSED                                                                [ 29%] tests/data/src/decode-local-stackstrings/test.yml::test-decode-local-stackstrings::Windows::32bit PASSED                                                              [ 31%] tests/data/src/decode-local-stackstrings/test.yml::test-decode-local-stackstrings::Windows::64bit PASSED                                                              [ 32%] tests/data/src/decode-rc4/test.yml::test-decode-rc4::Linux::32bit PASSED                                                                                              [ 34%] tests/data/src/decode-rc4/test.yml::test-decode-rc4::Windows::32bit PASSED                                                                                            [ 35%] tests/data/src/decode-rc4/test.yml::test-decode-rc4::Windows::64bit PASSED                                                                                            [ 37%] tests/data/src/decode-reencode-string/test.yml::test-decode-reencode-string::Linux::32bit PASSED                                                                      [ 39%] tests/data/src/decode-reencode-string/test.yml::test-decode-reencode-string::Windows::32bit PASSED                                                                    [ 40%] tests/data/src/decode-reencode-string/test.yml::test-decode-reencode-string::Windows::64bit PASSED                                                                    [ 42%] tests/data/src/decode-single-byte-xor/test.yml::test-decode-single-byte-xor::Linux::32bit PASSED                                                                      [ 43%] tests/data/src/decode-single-byte-xor/test.yml::test-decode-single-byte-xor::Windows::32bit PASSED                                                                    [ 45%] tests/data/src/decode-single-byte-xor/test.yml::test-decode-single-byte-xor::Windows::64bit PASSED                                                                    [ 46%] tests/data/src/decode-split-stackstrings/test.yml::test-decode-split-stackstrings::Linux::32bit PASSED                                                                [ 48%] tests/data/src/decode-split-stackstrings/test.yml::test-decode-split-stackstrings::Windows::32bit PASSED                                                              [ 50%] tests/data/src/decode-split-stackstrings/test.yml::test-decode-split-stackstrings::Windows::64bit PASSED                                                              [ 51%] tests/data/src/decode-stackstrings-move-to-global/test.yml::test-decode-stackstrings-move-to-global::Linux::32bit PASSED                                              [ 53%] tests/data/src/decode-stackstrings-move-to-global/test.yml::test-decode-stackstrings-move-to-global::Windows::32bit PASSED                                            [ 54%] tests/data/src/decode-stackstrings-move-to-global/test.yml::test-decode-stackstrings-move-to-global::Windows::64bit PASSED                                            [ 56%] tests/data/src/decode-string-with-header/test.yml::test-decode-string-with-header::Linux::32bit PASSED                                                                [ 57%] tests/data/src/decode-string-with-header/test.yml::test-decode-string-with-header::Windows::32bit PASSED                                                              [ 59%] tests/data/src/decode-string-with-header/test.yml::test-decode-string-with-header::Windows::64bit PASSED                                                              [ 60%] tests/data/src/decode-substitution-cipher/test.yml::test-decode-substitution-cipher::Linux::32bit PASSED                                                              [ 62%] tests/data/src/decode-substitution-cipher/test.yml::test-decode-substitution-cipher::Windows::32bit PASSED                                                            [ 64%] tests/data/src/decode-substitution-cipher/test.yml::test-decode-substitution-cipher::Windows::64bit PASSED                                                            [ 65%] tests/data/src/decode-tightstring/test.yml::test-decode-tightstring::Linux::32bit PASSED                                                                              [ 67%] tests/data/src/decode-tightstring/test.yml::test-decode-tightstring::Windows::32bit PASSED                                                                            [ 68%] tests/data/src/decode-tightstring/test.yml::test-decode-tightstring::Windows::64bit PASSED                                                                            [ 70%] tests/data/src/decode-to-global/test.yml::test-decode-to-global::Linux::32bit PASSED                                                                                  [ 71%] tests/data/src/decode-to-global/test.yml::test-decode-to-global::Windows::32bit PASSED                                                                                [ 73%] tests/data/src/decode-to-global/test.yml::test-decode-to-global::Windows::64bit PASSED                                                                                [ 75%] tests/data/src/decode-to-heap/test.yml::test-decode-to-heap::Linux::32bit PASSED                                                                                      [ 76%] tests/data/src/decode-to-heap/test.yml::test-decode-to-heap::Windows::32bit PASSED                                                                                    [ 78%] tests/data/src/decode-to-heap/test.yml::test-decode-to-heap::Windows::64bit PASSED                                                                                    [ 79%] tests/data/src/decode-to-output-buf/test.yml::test-decode-to-output-buf::Linux::32bit PASSED                                                                          [ 81%] tests/data/src/decode-to-output-buf/test.yml::test-decode-to-output-buf::Windows::32bit PASSED                                                                        [ 82%] tests/data/src/decode-to-output-buf/test.yml::test-decode-to-output-buf::Windows::64bit PASSED                                                                        [ 84%] tests/data/src/decode-to-stack/test.yml::test-decode-to-stack::Linux::32bit PASSED                                                                                    [ 85%] tests/data/src/decode-to-stack/test.yml::test-decode-to-stack::Windows::32bit PASSED                                                                                  [ 87%] tests/data/src/decode-to-stack/test.yml::test-decode-to-stack::Windows::64bit PASSED                                                                                  [ 89%] tests/data/src/decode-to-stack-rep-mov/test.yml::test-decode-to-stack-rep-mov::Linux::32bit PASSED                                                                    [ 90%] tests/data/src/decode-to-stack-rep-mov/test.yml::test-decode-to-stack-rep-mov::Windows::32bit PASSED                                                                  [ 92%] tests/data/src/decode-to-stack-rep-mov/test.yml::test-decode-to-stack-rep-mov::Windows::64bit PASSED                                                                  [ 93%] tests/data/src/decode-wrapped-decoder/test.yml::test-decode-wrapped-decoder::Linux::32bit XFAIL (unsupported test case (known issue))                                 [ 95%] tests/data/src/decode-wrapped-decoder/test.yml::test-decode-wrapped-decoder::Windows::32bit XFAIL (unsupported test case (known issue))                               [ 96%] tests/data/src/decode-wrapped-decoder/test.yml::test-decode-wrapped-decoder::Windows::64bit XFAIL (unsupported test case (known issue))                               [ 98%] tests/data/src/shellcode-stackstrings/test.yml::shellcode-stackstrings::Windows::x86 PASSED                                                                           [100%]                                                                                                                                                                              ================================================================= 58 passed, 6 xfailed in 152.74s (0:02:32) =================================================================