### PR TITLE
Floss ELF support

### DIFF
--- a/src/decode-base64/test.yml
+++ b/src/decode-base64/test.yml
@@ -28,6 +28,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-base64.c base64.c -o test-decode-base64.exe
 
-Xfail:
-    - Linux-32bit
-

--- a/src/decode-from-global/test.yml
+++ b/src/decode-from-global/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-from-global.c -o test-decode-from-global.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-from-heap/test.yml
+++ b/src/decode-from-heap/test.yml
@@ -26,5 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
       i686-w64-mingw32-clang test-decode-from-heap.c -o bin/test-decode-from-heap.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-from-stack/test.yml
+++ b/src/decode-from-stack/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-from-stack.c -o bin/test-decode-from-stack.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-global-stackstrings/test.yml
+++ b/src/decode-global-stackstrings/test.yml
@@ -29,5 +29,4 @@ Build instructions (Cross compile for Windows on Linux): |
 
 Xfail:
     - all
-    - Linux-32bit
 

--- a/src/decode-in-place/test.yml
+++ b/src/decode-in-place/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-in-place.c -o bin/test-decode-in-place.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-local-stackstrings/test.yml
+++ b/src/decode-local-stackstrings/test.yml
@@ -27,5 +27,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-local-stackstrings.c -o bin/test-decode-decode-stackstrings.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-rc4/test.yml
+++ b/src/decode-rc4/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-rc4.c -o bin/test-decode-rc4.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-reencode-string/test.yml
+++ b/src/decode-reencode-string/test.yml
@@ -29,5 +29,3 @@ Build instructions (Cross compile for Windows on Linux): |
     rm test-decode-reencode-string.exe
     i686-w64-mingw32-clang test-decode-reencode-string.c -o bin/test-decode-reencode-string.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-single-byte-xor/test.yml
+++ b/src/decode-single-byte-xor/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-single-byte-xor.c -o bin/test-decode-single-byte-xor.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-split-stackstrings/test.yml
+++ b/src/decode-split-stackstrings/test.yml
@@ -27,6 +27,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-split-stackstrings.c -o bin/test-decode-split-stackstrings.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-stackstrings-move-to-global/test.yml
+++ b/src/decode-stackstrings-move-to-global/test.yml
@@ -26,5 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-stackstrings-move-to-global.c -o bin/test-decode-stackstrings-move-to-global.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-string-by-index/test.yml
+++ b/src/decode-string-by-index/test.yml
@@ -30,6 +30,3 @@ Build instructions (Cross compile for Windows on Linux): |
     eg. rm test-decode-string-by-index.exe
     eg. i686-w64-mingw32-clang test-decode-string-by-index.c -o bin/test-decode-string-by-index.exe
 
-Xfail:
-    - Linux-32bit
-

--- a/src/decode-string-with-header/test.yml
+++ b/src/decode-string-with-header/test.yml
@@ -26,5 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-string-with-header.c -o bin/test-decode-string-with-header.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-substitution-cipher/test.yml
+++ b/src/decode-substitution-cipher/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-substitution-cipher.c -o bin/test-decode-substitution-cipher.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-tightstring/test.yml
+++ b/src/decode-tightstring/test.yml
@@ -27,6 +27,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-tightstring.c -o bin/test-decode-tightstring.exe
 
-Xfail:
-    - Linux-32bit
-

--- a/src/decode-to-global/test.yml
+++ b/src/decode-to-global/test.yml
@@ -26,6 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-global.c -o bin/test-decode-to-global.exe
 
-Xfail:
-    - Linux-32bit
-

--- a/src/decode-to-heap/test.yml
+++ b/src/decode-to-heap/test.yml
@@ -26,6 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-heap.c -o bin/test-decode-to-heap.exe
 
-Xfail:
-    - Linux-32bit
-

--- a/src/decode-to-output-buf/test.yml
+++ b/src/decode-to-output-buf/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-output-buf.c -o bin/test-decode-to-output-buf.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-to-stack-rep-mov/test.yml
+++ b/src/decode-to-stack-rep-mov/test.yml
@@ -26,5 +26,3 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-stack-rep-mov.c -o bin/test-decode-to-stack-rep-mov.exe
 
-Xfail:
-    - Linux-32bit

--- a/src/decode-to-stack/test.yml
+++ b/src/decode-to-stack/test.yml
@@ -26,6 +26,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-stack.c -o bin/test-decode-to-stack.exe
 
-Xfail:
-    - Linux-32bit
 

--- a/src/decode-wrapped-decoder/test.yml
+++ b/src/decode-wrapped-decoder/test.yml
@@ -31,5 +31,4 @@ Build instructions (Cross compile for Windows on Linux): |
 
 Xfail:
     - all
-    - Linux-32bit
 


### PR DESCRIPTION
Enabling the ELF test cases by removing Linux from Xfail.