### PR TITLE
Fix flare-floss lints failing

### DIFF
--- a/language/go/go-binaries-all-versions/go_binary_generator.py
+++ b/language/go/go-binaries-all-versions/go_binary_generator.py
@@ -27,11 +27,9 @@ go_versions = """
 
 f = open("docker-compose.yml", "w")
 
-f.write(
-    """services:
+f.write("""services:
   app:
-    build: ."""
-)
+    build: .""")
 
 f.close()
 
@@ -46,30 +44,22 @@ for arch in architecture.keys():
 
         f = open("Dockerfile", "w")
 
-        f.write(
-            """# syntax=docker/dockerfile:1
+        f.write("""# syntax=docker/dockerfile:1
 FROM golang:{}
 
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download
 COPY *.go ./
-RUN GOOS=windows GOARCH={} go install main{}.go""".format(
-                version, arch, architecture[arch]
-            )
-        )
+RUN GOOS=windows GOARCH={} go install main{}.go""".format(version, arch, architecture[arch]))
         f.close()
 
         f = open("go.mod", "w")
 
-        f.write(
-            """module go-test
+        f.write("""module go-test
 
 go {}
-        """.format(
-                version
-            )
-        )
+        """.format(version))
 
         f.close()
 

--- a/language/rust/rust-binaries-all-versions/rust_binary_generator.py
+++ b/language/rust/rust-binaries-all-versions/rust_binary_generator.py
@@ -25,11 +25,9 @@ rust_versions = """
 
 f = open("docker-compose.yml", "w")
 
-f.write(
-    """services:
+f.write("""services:
   app:
-    build: ."""
-)
+    build: .""")
 
 f.close()
 
@@ -46,8 +44,7 @@ for arch in architecture.keys():
 
         target = architecture[arch]
 
-        f.write(
-            """# syntax=docker/dockerfile:1
+        f.write("""# syntax=docker/dockerfile:1
 FROM rust:{}
 ENV USER root
 RUN cargo new known_binary
@@ -58,10 +55,7 @@ RUN rustup target add {}
 RUN rustup update
 RUN cargo build --release --target {}
 
-""".format(
-                version, target, target
-            )
-        )
+""".format(version, target, target))
         f.close()
 
         subprocess.call(["docker", "build", "--tag", "rust-test", "."])


### PR DESCRIPTION
This formats the two generator scripts using `black`. Previously whenever the pre commit hooks ran in `flare-floss` the submodule would also be detected and fail.