### PR TITLE
Enable wrapped decoder test

### DIFF
--- a/src/decode-wrapped-decoder/test.yml
+++ b/src/decode-wrapped-decoder/test.yml
@@ -29,6 +29,4 @@ Build instructions (Cross compile for Windows on Linux): |
     rm test-decode-wrapped-decoder.exe
     i686-w64-mingw32-clang test-decode-wrapped-decoder.c -o bin/test-decode-wrapped-decoder.exe
 
-Xfail:
-    - all
 


### PR DESCRIPTION
## Summary

Remove the outdated `Xfail` marker from the wrapped decoder test.

The test now passes successfully for all available binaries:

* Linux 32-bit
* Windows 32-bit
* Windows 64-bit

## Testing

```bash
python -m pytest tests/data/src/decode-wrapped-decoder/test.yml -vv
```

Result:

```text
3 passed
```

Related to mandiant/flare-floss#104.
