### PR TITLE
Enable global stackstrings test

### DIFF
--- a/src/decode-global-stackstrings/test.yml
+++ b/src/decode-global-stackstrings/test.yml
@@ -27,6 +27,4 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-global-stackstrings.c -o bin/test-decode-decode-stackstrings.exe
 
-Xfail:
-    - all
 


### PR DESCRIPTION
## Summary

Remove the outdated `Xfail` marker from the global stackstrings test.

This test validates detection of strings constructed character-by-character in global memory.

## Testing

Tested together with the corresponding `flare-floss` implementation:

```bash
python -m pytest tests/data/src/decode-global-stackstrings/test.yml -vv
```

Result:

```text
3 passed
```

The test passed for:

* Linux
* Windows 32-bit
* Windows 64-bit

Related to mandiant/flare-floss#37.
